### PR TITLE
Loader Cache Decorators 

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		E04341FC28EB7D8300643A0C /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E04341F928EB7D8300643A0C /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E04341FD28EB7D8300643A0C /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E04341FA28EB7D8300643A0C /* EssentialFeediOS.framework */; };
 		E04341FE28EB7D8300643A0C /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E04341FA28EB7D8300643A0C /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E043A58E28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E043A58D28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift */; };
 		E07E900828ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E900728ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift */; };
 		E07E900A28ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E900928ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift */; };
 		E07E900C28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E900B28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
@@ -62,6 +63,7 @@
 		E0149F5328EB7AD800081952 /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E04341F928EB7D8300643A0C /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E04341FA28EB7D8300643A0C /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E043A58D28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		E07E900728ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		E07E900928ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		E07E900B28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 				E07E900F28EEDBA4009E78E7 /* Helpers */,
 				E07E900728ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift */,
 				E07E900B28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
+				E043A58D28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -269,6 +272,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E07E901328EEDC3A009E78E7 /* SharedTestHelpers.swift in Sources */,
+				E043A58E28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				E07E900C28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				E07E900828ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				E07E901128EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		E07E900E28EEDB2B009E78E7 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E900D28EEDB2B009E78E7 /* FeedImageDataLoaderWithFallbackComposite.swift */; };
 		E07E901128EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E901028EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift */; };
 		E07E901328EEDC3A009E78E7 /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E901228EEDC3A009E78E7 /* SharedTestHelpers.swift */; };
+		E0952ECB28F744A00011FE47 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0952ECA28F744A00011FE47 /* FeedLoaderCacheDecorator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 		E07E900D28EEDB2B009E78E7 /* FeedImageDataLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		E07E901028EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		E07E901228EEDC3A009E78E7 /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
+		E0952ECA28F744A00011FE47 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +122,7 @@
 			children = (
 				E07E900928ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift */,
 				E07E900D28EEDB2B009E78E7 /* FeedImageDataLoaderWithFallbackComposite.swift */,
+				E0952ECA28F744A00011FE47 /* FeedLoaderCacheDecorator.swift */,
 				E0149F4028EB7AD700081952 /* AppDelegate.swift */,
 				E0149F4228EB7AD700081952 /* SceneDelegate.swift */,
 				E0149F4428EB7AD700081952 /* ViewController.swift */,
@@ -268,6 +271,7 @@
 				E0149F4528EB7AD700081952 /* ViewController.swift in Sources */,
 				E0149F4128EB7AD700081952 /* AppDelegate.swift in Sources */,
 				E07E900A28ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift in Sources */,
+				E0952ECB28F744A00011FE47 /* FeedLoaderCacheDecorator.swift in Sources */,
 				E0149F4328EB7AD700081952 /* SceneDelegate.swift in Sources */,
 				E07E900E28EEDB2B009E78E7 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 			);

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		E07E901128EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E901028EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift */; };
 		E07E901328EEDC3A009E78E7 /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E901228EEDC3A009E78E7 /* SharedTestHelpers.swift */; };
 		E0952ECB28F744A00011FE47 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0952ECA28F744A00011FE47 /* FeedLoaderCacheDecorator.swift */; };
+		E0BA1B3E28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B3D28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +77,7 @@
 		E07E901028EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		E07E901228EEDC3A009E78E7 /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		E0952ECA28F744A00011FE47 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
+		E0BA1B3D28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +143,7 @@
 				E07E900728ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift */,
 				E07E900B28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
 				E043A58D28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift */,
+				E0BA1B3D28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -282,6 +285,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E07E901328EEDC3A009E78E7 /* SharedTestHelpers.swift in Sources */,
+				E0BA1B3E28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				E043A59228F352DE00D9D619 /* XCTestCase+FeedLoader.swift in Sources */,
 				E043A58E28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				E07E900C28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		E04341FD28EB7D8300643A0C /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E04341FA28EB7D8300643A0C /* EssentialFeediOS.framework */; };
 		E04341FE28EB7D8300643A0C /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E04341FA28EB7D8300643A0C /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E043A58E28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E043A58D28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift */; };
+		E043A59028F3520B00D9D619 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = E043A58F28F3520B00D9D619 /* FeedLoaderStub.swift */; };
 		E07E900828ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E900728ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift */; };
 		E07E900A28ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E900928ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift */; };
 		E07E900C28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E900B28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
@@ -64,6 +65,7 @@
 		E04341F928EB7D8300643A0C /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E04341FA28EB7D8300643A0C /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E043A58D28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		E043A58F28F3520B00D9D619 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		E07E900728ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		E07E900928ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		E07E900B28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 			children = (
 				E07E901028EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift */,
 				E07E901228EEDC3A009E78E7 /* SharedTestHelpers.swift */,
+				E043A58F28F3520B00D9D619 /* FeedLoaderStub.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 				E043A58E28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				E07E900C28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				E07E900828ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
+				E043A59028F3520B00D9D619 /* FeedLoaderStub.swift in Sources */,
 				E07E901128EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		E04341FE28EB7D8300643A0C /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E04341FA28EB7D8300643A0C /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E043A58E28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E043A58D28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift */; };
 		E043A59028F3520B00D9D619 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = E043A58F28F3520B00D9D619 /* FeedLoaderStub.swift */; };
+		E043A59228F352DE00D9D619 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E043A59128F352DE00D9D619 /* XCTestCase+FeedLoader.swift */; };
 		E07E900828ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E900728ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift */; };
 		E07E900A28ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E900928ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift */; };
 		E07E900C28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E900B28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */; };
@@ -66,6 +67,7 @@
 		E04341FA28EB7D8300643A0C /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E043A58D28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		E043A58F28F3520B00D9D619 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
+		E043A59128F352DE00D9D619 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		E07E900728ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		E07E900928ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		E07E900B28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				E07E901028EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift */,
 				E07E901228EEDC3A009E78E7 /* SharedTestHelpers.swift */,
 				E043A58F28F3520B00D9D619 /* FeedLoaderStub.swift */,
+				E043A59128F352DE00D9D619 /* XCTestCase+FeedLoader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E07E901328EEDC3A009E78E7 /* SharedTestHelpers.swift in Sources */,
+				E043A59228F352DE00D9D619 /* XCTestCase+FeedLoader.swift in Sources */,
 				E043A58E28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				E07E900C28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				E07E900828ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		E07E901328EEDC3A009E78E7 /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E901228EEDC3A009E78E7 /* SharedTestHelpers.swift */; };
 		E0952ECB28F744A00011FE47 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0952ECA28F744A00011FE47 /* FeedLoaderCacheDecorator.swift */; };
 		E0BA1B3E28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B3D28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
+		E0BA1B4028FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B3F28FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +79,7 @@
 		E07E901228EEDC3A009E78E7 /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		E0952ECA28F744A00011FE47 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		E0BA1B3D28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		E0BA1B3F28FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +166,7 @@
 				E07E901228EEDC3A009E78E7 /* SharedTestHelpers.swift */,
 				E043A58F28F3520B00D9D619 /* FeedLoaderStub.swift */,
 				E043A59128F352DE00D9D619 /* XCTestCase+FeedLoader.swift */,
+				E0BA1B3F28FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				E0BA1B3E28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				E043A59228F352DE00D9D619 /* XCTestCase+FeedLoader.swift in Sources */,
 				E043A58E28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
+				E0BA1B4028FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift in Sources */,
 				E07E900C28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				E07E900828ECB958009E78E7 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				E043A59028F3520B00D9D619 /* FeedLoaderStub.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		E0952ECB28F744A00011FE47 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0952ECA28F744A00011FE47 /* FeedLoaderCacheDecorator.swift */; };
 		E0BA1B3E28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B3D28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		E0BA1B4028FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B3F28FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift */; };
+		E0BA1B4228FAD00900F1F75B /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B4128FAD00900F1F75B /* XCTestCase+FeedImageDataLoader.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,7 @@
 		E0952ECA28F744A00011FE47 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		E0BA1B3D28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		E0BA1B3F28FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
+		E0BA1B4128FAD00900F1F75B /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,11 +164,12 @@
 		E07E900F28EEDBA4009E78E7 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				E07E901028EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift */,
 				E07E901228EEDC3A009E78E7 /* SharedTestHelpers.swift */,
 				E043A58F28F3520B00D9D619 /* FeedLoaderStub.swift */,
-				E043A59128F352DE00D9D619 /* XCTestCase+FeedLoader.swift */,
 				E0BA1B3F28FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift */,
+				E07E901028EEDBD9009E78E7 /* XCTestCase+MemoryLeakTracking.swift */,
+				E043A59128F352DE00D9D619 /* XCTestCase+FeedLoader.swift */,
+				E0BA1B4128FAD00900F1F75B /* XCTestCase+FeedImageDataLoader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -290,6 +293,7 @@
 				E07E901328EEDC3A009E78E7 /* SharedTestHelpers.swift in Sources */,
 				E0BA1B3E28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				E043A59228F352DE00D9D619 /* XCTestCase+FeedLoader.swift in Sources */,
+				E0BA1B4228FAD00900F1F75B /* XCTestCase+FeedImageDataLoader.swift in Sources */,
 				E043A58E28F34C3000D9D619 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				E0BA1B4028FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift in Sources */,
 				E07E900C28ED2331009E78E7 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		E0BA1B3E28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B3D28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		E0BA1B4028FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B3F28FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift */; };
 		E0BA1B4228FAD00900F1F75B /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B4128FAD00900F1F75B /* XCTestCase+FeedImageDataLoader.swift */; };
+		E0BA1B4628FB1EDA00F1F75B /* FeedImageDataLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B4528FB1EDA00F1F75B /* FeedImageDataLoaderCacheDecorator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +83,7 @@
 		E0BA1B3D28F9E96900F1F75B /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		E0BA1B3F28FA0F6E00F1F75B /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		E0BA1B4128FAD00900F1F75B /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
+		E0BA1B4528FB1EDA00F1F75B /* FeedImageDataLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +131,7 @@
 				E07E900928ECC59B009E78E7 /* FeedLoaderWithFallbackComposite.swift */,
 				E07E900D28EEDB2B009E78E7 /* FeedImageDataLoaderWithFallbackComposite.swift */,
 				E0952ECA28F744A00011FE47 /* FeedLoaderCacheDecorator.swift */,
+				E0BA1B4528FB1EDA00F1F75B /* FeedImageDataLoaderCacheDecorator.swift */,
 				E0149F4028EB7AD700081952 /* AppDelegate.swift */,
 				E0149F4228EB7AD700081952 /* SceneDelegate.swift */,
 				E0149F4428EB7AD700081952 /* ViewController.swift */,
@@ -283,6 +286,7 @@
 				E0952ECB28F744A00011FE47 /* FeedLoaderCacheDecorator.swift in Sources */,
 				E0149F4328EB7AD700081952 /* SceneDelegate.swift in Sources */,
 				E07E900E28EEDB2B009E78E7 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
+				E0BA1B4628FB1EDA00F1F75B /* FeedImageDataLoaderCacheDecorator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EssentialApp/EssentialApp.xcworkspace/xcshareddata/xcschemes/EssentialApp.xcscheme
+++ b/EssentialApp/EssentialApp.xcworkspace/xcshareddata/xcschemes/EssentialApp.xcscheme
@@ -30,7 +30,6 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -22,9 +22,15 @@ public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     -> FeedImageDataLoaderTask {
         decoratee.loadImageData(from: url) { [weak self] result in
             completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
+                self?.cache.saveIgnoringResult(data, for: url)
                 return data
             })
         }
+    }
+}
+
+private extension FeedImageDataCache {
+    func saveIgnoringResult(_ data: Data, for url: URL) {
+        save(data, for: url) { _ in }
     }
 }

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -1,0 +1,30 @@
+//
+//  FeedImageDataLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by Viral on 15/10/22.
+//
+
+import Foundation
+import EssentialFeed
+
+public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    private let decoratee: FeedImageDataLoader
+    private let cache: FeedImageDataCache
+
+    public init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+
+    public func loadImageData(from url: URL,
+                              completion: @escaping (FeedImageDataLoader.Result) -> Void)
+    -> FeedImageDataLoaderTask {
+        decoratee.loadImageData(from: url) { [weak self] result in
+            completion(result.map { data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            })
+        }
+    }
+}

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -19,9 +19,15 @@ public final class FeedLoaderCacheDecorator: FeedLoader {
     public func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
             completion(result.map { feed in
-                self?.cache.save(feed) { _ in }
+                self?.cache.saveIgnoringResult(feed)
                 return feed
             })
         }
+    }
+}
+
+private extension FeedCache {
+    func saveIgnoringResult(_ feed: [FeedImage]) {
+        save(feed) { _ in }
     }
 }

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -1,0 +1,27 @@
+//
+//  FeedLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by Viral on 13/10/22.
+//
+
+import EssentialFeed
+
+public final class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+    private let cache: FeedCache
+
+    public init(decoratee: FeedLoader, cache: FeedCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+
+    public func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load { [weak self] result in
+            completion(result.map { feed in
+                self?.cache.save(feed) { _ in }
+                return feed
+            })
+        }
+    }
+}

--- a/EssentialApp/EssentialApp/SceneDelegate.swift
+++ b/EssentialApp/EssentialApp/SceneDelegate.swift
@@ -6,47 +6,23 @@
 //
 
 import UIKit
+import EssentialFeed
+import EssentialFeediOS
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
-    }
+        let url = URL(string: "https://ile-api.essentialdeveloper.com/essential-feed/v1/feed")!
 
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+        let session = URLSession(configuration: .ephemeral)
+        let client = URLSessionHTTPClient(session: session)
+        let feedLoader = RemoteFeedLoader(url: url, client: client)
+        let imageLoader = RemoteFeedImageDataLoader(client: client)
+        window?.rootViewController = FeedUIComposer.feedComposeWith(feedLoader: feedLoader, imageLoader: imageLoader)
     }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
-    }
-
-    func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
-    }
-
 
 }
 

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -8,12 +8,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedImageDataCache {
-    typealias Result = Swift.Result<Void, Error>
-
-    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
-}
-
 final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     private let decoratee: FeedImageDataLoader
     private let cache: FeedImageDataCache

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -7,27 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
-    private let decoratee: FeedImageDataLoader
-    private let cache: FeedImageDataCache
-
-    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-
-    func loadImageData(from url: URL,
-                       completion: @escaping (FeedImageDataLoader.Result) -> Void)
-    -> FeedImageDataLoaderTask {
-        decoratee.loadImageData(from: url) { [weak self] result in
-            completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
-                return data
-            })
-        }
-    }
-}
+import EssentialApp
 
 class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
 

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -8,17 +8,29 @@
 import XCTest
 import EssentialFeed
 
+protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}
+
 final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     private let decoratee: FeedImageDataLoader
+    private let cache: FeedImageDataCache
 
-    init(decoratee: FeedImageDataLoader) {
+    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
         self.decoratee = decoratee
+        self.cache = cache
     }
 
     func loadImageData(from url: URL,
                        completion: @escaping (FeedImageDataLoader.Result) -> Void)
     -> FeedImageDataLoaderTask {
-        decoratee.loadImageData(from: url, completion: completion)
+        decoratee.loadImageData(from: url) { [weak self] result in
+            let imageData = try? result.get()
+            self?.cache.save(imageData ?? Data(), for: url) { _ in }
+            completion(result)
+        }
     }
 }
 
@@ -66,13 +78,38 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTes
         }
     }
 
+    func test_loadImageData_cachesLoadedDataOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let url = anyURL()
+        let imageData = anyData()
+        let (sut, loader) = makeSUT(cache: cache)
+
+        _ = sut.loadImageData(from: url) { _ in }
+        loader.complete(with: imageData)
+
+        XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+    }
+
     // MARK: - HELPER
-    private func makeSUT(file: StaticString = #file, line: UInt = #line)
+    private func makeSUT(cache: CacheSpy = .init(), file: StaticString = #file, line: UInt = #line)
     -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
         let loader = FeedImageDataLoaderSpy()
-        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(sut, file: file, line: line)
         trackForMemoryLeaks(loader, file: file, line: line)
         return (sut, loader)
+    }
+
+    private class CacheSpy: FeedImageDataCache {
+        private(set) var messages = [Message]()
+
+        enum Message: Equatable {
+            case save(data: Data, for: URL)
+        }
+
+        func save(_ data: Data, for url: URL, completion: @escaping (FeedImageDataCache.Result) -> Void) {
+            messages.append(.save(data: data, for: url))
+            completion(.success(()))
+        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -68,8 +68,8 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
 
     // MARK: - HELPER
     private func makeSUT(file: StaticString = #file, line: UInt = #line)
-    -> (sut: FeedImageDataLoader, loader: LoaderSpy) {
-        let loader = LoaderSpy()
+    -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
+        let loader = FeedImageDataLoaderSpy()
         let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
         trackForMemoryLeaks(sut, file: file, line: line)
         trackForMemoryLeaks(loader, file: file, line: line)
@@ -97,40 +97,5 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         action()
 
         wait(for: [exp], timeout: 1.0)
-    }
-
-    private final class LoaderSpy: FeedImageDataLoader {
-        private(set) var cancelledURLs = [URL]()
-
-        var loadedURLs: [URL] {
-            message.map(\.url)
-        }
-
-        private struct Task: FeedImageDataLoaderTask {
-            let callback: () -> Void
-
-            func cancel() {
-                callback()
-            }
-        }
-
-        private var message = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-
-        func loadImageData(from url: URL,
-                           completion: @escaping (FeedImageDataLoader.Result) -> Void)
-        -> FeedImageDataLoaderTask {
-            message.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-
-        func complete(with error: Error, at index: Int = 0) {
-            message[index].completion(.failure(error))
-        }
-
-        func complete(with data: Data, at index: Int = 0) {
-            message[index].completion(.success(data))
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -1,0 +1,136 @@
+//
+//  FeedImageDataLoaderCacheDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by Viral on 15/10/22.
+//
+
+import XCTest
+import EssentialFeed
+
+final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    private let decoratee: FeedImageDataLoader
+
+    init(decoratee: FeedImageDataLoader) {
+        self.decoratee = decoratee
+    }
+
+    func loadImageData(from url: URL,
+                       completion: @escaping (FeedImageDataLoader.Result) -> Void)
+    -> FeedImageDataLoaderTask {
+        decoratee.loadImageData(from: url, completion: completion)
+    }
+}
+
+class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+
+    func test_init_doesNotLoadImageData() {
+        let (_ ,loader) = makeSUT()
+
+        XCTAssertTrue(loader.loadedURLs.isEmpty, "Expected no loaded URLs")
+    }
+
+    func test_loadImageData_loadsFromLoader() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+
+        _ = sut.loadImageData(from: url) { _ in }
+
+        XCTAssertEqual(loader.loadedURLs, [url], "Expected to load URL from loader")
+    }
+
+    func test_cancelLoadImageData_cancelsLoaderTask() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+
+        let task = sut.loadImageData(from: url) { _ in }
+        task.cancel()
+
+        XCTAssertEqual(loader.cancelledURLs, [url], "Expected to cancel URL loading from loader")
+    }
+
+    func test_loadImageData_deliversDataOnLoaderSuccess() {
+        let imageData = anyData()
+        let (sut, loader) = makeSUT()
+
+        expect(sut, toCompleteWith: .success(imageData)) {
+            loader.complete(with: imageData)
+        }
+    }
+
+    func test_loadImageData_deliversErrorOnLoaderFailure() {
+        let (sut, loader) = makeSUT()
+
+        expect(sut, toCompleteWith: .failure(anyNSError())) {
+            loader.complete(with: anyNSError())
+        }
+    }
+
+    // MARK: - HELPER
+    private func makeSUT(file: StaticString = #file, line: UInt = #line)
+    -> (sut: FeedImageDataLoader, loader: LoaderSpy) {
+        let loader = LoaderSpy()
+        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        return (sut, loader)
+    }
+
+    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+                case let (.success(receivedFeed), .success(expectedFeed)):
+                    XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+
+                case (.failure, .failure):
+                    break
+
+                default:
+                    XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+
+            exp.fulfill()
+        }
+
+        action()
+
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    private final class LoaderSpy: FeedImageDataLoader {
+        private(set) var cancelledURLs = [URL]()
+
+        var loadedURLs: [URL] {
+            message.map(\.url)
+        }
+
+        private struct Task: FeedImageDataLoaderTask {
+            let callback: () -> Void
+
+            func cancel() {
+                callback()
+            }
+        }
+
+        private var message = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+
+        func loadImageData(from url: URL,
+                           completion: @escaping (FeedImageDataLoader.Result) -> Void)
+        -> FeedImageDataLoaderTask {
+            message.append((url, completion))
+            return Task { [weak self] in
+                self?.cancelledURLs.append(url)
+            }
+        }
+
+        func complete(with error: Error, at index: Int = 0) {
+            message[index].completion(.failure(error))
+        }
+
+        func complete(with data: Data, at index: Int = 0) {
+            message[index].completion(.success(data))
+        }
+    }
+}

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -22,7 +22,7 @@ final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     }
 }
 
-class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
 
     func test_init_doesNotLoadImageData() {
         let (_ ,loader) = makeSUT()
@@ -74,28 +74,5 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         trackForMemoryLeaks(sut, file: file, line: line)
         trackForMemoryLeaks(loader, file: file, line: line)
         return (sut, loader)
-    }
-
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-                case let (.success(receivedFeed), .success(expectedFeed)):
-                    XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-
-                case (.failure, .failure):
-                    break
-
-                default:
-                    XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-
-            exp.fulfill()
-        }
-
-        action()
-
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -94,9 +94,9 @@ final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
     // MARK: - Helpers
 
     private func makeSUT(file: StaticString = #file, line: UInt = #line)
-    -> (sut: FeedImageDataLoader, primaryLoader: LoaderSpy, fallbackLoader: LoaderSpy) {
-        let primaryLoader = LoaderSpy()
-        let fallbackLoader = LoaderSpy()
+    -> (sut: FeedImageDataLoader, primaryLoader: FeedImageDataLoaderSpy, fallbackLoader: FeedImageDataLoaderSpy) {
+        let primaryLoader = FeedImageDataLoaderSpy()
+        let fallbackLoader = FeedImageDataLoaderSpy()
 
         let sut = FeedImageDataLoaderWithFallbackComposite(primaryLoader: primaryLoader,
                                                            fallbackLoader: fallbackLoader)
@@ -127,35 +127,5 @@ final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         action()
 
         wait(for: [exp], timeout: 1.0)
-    }
-
-    private class LoaderSpy: FeedImageDataLoader {
-        private var message = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-        private(set) var cancelledURLs = [URL]()
-
-        var loadedURLs: [URL] {
-            return message.map { $0.url }
-        }
-
-        private struct Task: FeedImageDataLoaderTask {
-            let callback: () -> Void
-            func cancel() { callback() }
-        }
-
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void)
-        -> FeedImageDataLoaderTask {
-            message.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-
-        func complete(with error: Error, at index: Int = 0) {
-            message[index].completion(.failure(error))
-        }
-
-        func complete(with data: Data, at index: Int = 0) {
-            message[index].completion(.success(data))
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
+final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase, FeedImageDataLoaderTestCase {
 
     func test_init_doesNotLoadImageData() {
         let (_ , primaryLoader, fallbackLoader) = makeSUT()
@@ -105,27 +105,5 @@ final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
 
         return (sut, primaryLoader, fallbackLoader)
-    }
-
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result,
-                        when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait to load completion")
-
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-                case let (.success(receivedFeed), .success(expectedFeed)):
-                    XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-
-                case (.failure, .failure):
-                    break
-
-                default:
-                    XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            exp.fulfill()
-        }
-        action()
-
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,10 +25,10 @@ final class FeedLoaderCacheDecorator: FeedLoader {
 
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            if let feed = try? result.get() {
+            completion(result.map { feed in
                 self?.cache.save(feed) { _ in }
-            }
-            completion(result)
+                return feed
+            })
         }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,12 +8,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedCache {
-    typealias Result = Swift.Result<Void, Error>
-
-    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
-}
-
 final class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
     private let cache: FeedCache

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -7,25 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-final class FeedLoaderCacheDecorator: FeedLoader {
-    private let decoratee: FeedLoader
-    private let cache: FeedCache
-
-    init(decoratee: FeedLoader, cache: FeedCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-
-    func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load { [weak self] result in
-            completion(result.map { feed in
-                self?.cache.save(feed) { _ in }
-                return feed
-            })
-        }
-    }
-}
+import EssentialApp
 
 class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCases {
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -1,0 +1,78 @@
+//
+//  FeedLoaderCacheDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by Viral on 10/10/22.
+//
+
+import XCTest
+import EssentialFeed
+
+final class FeedLoaderCacheDecorator: FeedLoader {
+    let decoratee: FeedLoader
+
+    init(decoratee: FeedLoader) {
+        self.decoratee = decoratee
+    }
+
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load(completion: completion)
+    }
+}
+
+class FeedLoaderCacheDecoratorTests: XCTestCase {
+
+    func test_load_deliversFeedOnLoaderSuccess() {
+        let feed = uniqueFeed()
+        let loader = LoaderStub(result: .success(feed))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+
+        expect(sut, toCompleteWith: .success(feed))
+    }
+
+    func test_laod_deliversErrorOnLoaderFailure() {
+        let feedError = anyNSError()
+        let loader = LoaderStub(result: .failure(feedError))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+
+        expect(sut, toCompleteWith: .failure(feedError))
+    }
+
+    // MARK: - Helpers
+
+    private func uniqueFeed() -> [FeedImage] {
+        [FeedImage(id: UUID(), description: nil, location: nil, url: URL(string: "http://any-url.com")!)]
+    }
+
+    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result,
+                        file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait to load completion")
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+                case let (.success(receviedFeed), .success(expectedFeed)):
+                    XCTAssertEqual(receviedFeed, expectedFeed, file: file, line: line)
+
+                case (.failure, .failure):
+                    break
+
+                default:
+                    XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    private class LoaderStub: FeedLoader {
+        private let result: FeedLoader.Result
+
+        init(result: FeedLoader.Result) {
+            self.result = result
+        }
+
+        func load(completion: @escaping (FeedLoader.Result) -> Void) {
+            completion(result)
+        }
+    }
+}

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,15 +8,27 @@
 import XCTest
 import EssentialFeed
 
-final class FeedLoaderCacheDecorator: FeedLoader {
-    let decoratee: FeedLoader
+protocol FeedCache {
+    typealias Result = Swift.Result<Void, Error>
 
-    init(decoratee: FeedLoader) {
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}
+
+final class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+    private let cache: FeedCache
+
+    init(decoratee: FeedLoader, cache: FeedCache) {
         self.decoratee = decoratee
+        self.cache = cache
     }
 
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load(completion: completion)
+        decoratee.load { [weak self] result in
+            let feed = try? result.get()
+            self?.cache.save(feed ?? []) { _ in }
+            completion(result)
+        }
     }
 }
 
@@ -36,13 +48,37 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCases {
         expect(sut, toCompleteWith: .failure(feedError))
     }
 
+    func test_load_cacheLoaderFeedOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let feed = uniqueFeed()
+        let sut = makeSUT(loaderResult: .success(feed), cache: cache)
+
+        sut.load { _ in }
+
+        XCTAssertEqual(cache.messages, [.save(feed)])
+    }
+
     // MARK: - Helpers
-    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file,
+    private func makeSUT(loaderResult: FeedLoader.Result, cache: CacheSpy = .init(),
+                         file: StaticString = #file,
                          line: UInt = #line) -> FeedLoader {
         let loader = FeedLoaderStub(result: loaderResult)
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(sut, file: file, line: line)
         trackForMemoryLeaks(loader, file: file, line: line)
         return sut
+    }
+
+    private class CacheSpy: FeedCache {
+        private(set) var messages = [Message]()
+
+        enum Message: Equatable {
+            case save([FeedImage])
+        }
+
+        func save(_ feed: [FeedImage], completion: @escaping (FeedCache.Result) -> Void) {
+            messages.append(.save(feed))
+            completion(.success(()))
+        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -40,10 +40,6 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func uniqueFeed() -> [FeedImage] {
-        [FeedImage(id: UUID(), description: nil, location: nil, url: URL(string: "http://any-url.com")!)]
-    }
-
     private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result,
                         file: StaticString = #file, line: UInt = #line) {
         let exp = expectation(description: "Wait to load completion")

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,17 +24,25 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCases {
 
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = FeedLoaderStub(result: .success(feed))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .success(feed))
 
         expect(sut, toCompleteWith: .success(feed))
     }
 
     func test_laod_deliversErrorOnLoaderFailure() {
         let feedError = anyNSError()
-        let loader = FeedLoaderStub(result: .failure(feedError))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .failure(feedError))
 
         expect(sut, toCompleteWith: .failure(feedError))
+    }
+
+    // MARK: - Helpers
+    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file,
+                         line: UInt = #line) -> FeedLoader {
+        let loader = FeedLoaderStub(result: loaderResult)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        return sut
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,7 +24,7 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
 
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = LoaderStub(result: .success(feed))
+        let loader = FeedLoaderStub(result: .success(feed))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
 
         expect(sut, toCompleteWith: .success(feed))
@@ -32,7 +32,7 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
 
     func test_laod_deliversErrorOnLoaderFailure() {
         let feedError = anyNSError()
-        let loader = LoaderStub(result: .failure(feedError))
+        let loader = FeedLoaderStub(result: .failure(feedError))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
 
         expect(sut, toCompleteWith: .failure(feedError))
@@ -62,17 +62,5 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
         }
 
         wait(for: [exp], timeout: 1.0)
-    }
-
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -20,7 +20,7 @@ final class FeedLoaderCacheDecorator: FeedLoader {
     }
 }
 
-class FeedLoaderCacheDecoratorTests: XCTestCase {
+class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCases {
 
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
@@ -36,27 +36,5 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
 
         expect(sut, toCompleteWith: .failure(feedError))
-    }
-
-    // MARK: - Helpers
-
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result,
-                        file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait to load completion")
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-                case let (.success(receviedFeed), .success(expectedFeed)):
-                    XCTAssertEqual(receviedFeed, expectedFeed, file: file, line: line)
-
-                case (.failure, .failure):
-                    break
-
-                default:
-                    XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            exp.fulfill()
-        }
-
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -65,8 +65,4 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
 
         wait(for: [exp], timeout: 1.0)
     }
-
-    private func uniqueFeed() -> [FeedImage] {
-        [FeedImage(id: UUID(), description: nil, location: nil, url: URL(string: "http://any-url.com")!)]
-    }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -35,8 +35,8 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     // MARK: - Helpers
     private func makeSUT(primaryResult: FeedLoader.Result, fallbackResult: FeedLoader.Result,
                          file: StaticString = #file, line: UInt = #line) -> FeedLoaderWithFallbackComposite {
-        let primaryLoader = LoaderStub(result: primaryResult)
-        let fallbackLoader = LoaderStub(result: fallbackResult)
+        let primaryLoader = FeedLoaderStub(result: primaryResult)
+        let fallbackLoader = FeedLoaderStub(result: fallbackResult)
         let sut = FeedLoaderWithFallbackComposite(
             primaryLoader: primaryLoader,
             fallbackLoader: fallbackLoader)
@@ -68,17 +68,5 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
 
     private func uniqueFeed() -> [FeedImage] {
         [FeedImage(id: UUID(), description: nil, location: nil, url: URL(string: "http://any-url.com")!)]
-    }
-
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
+final class FeedLoaderWithFallbackCompositeTests: XCTestCase, FeedLoaderTestCases {
 
     func test_load_deliversPrimaryFeedOnPrimaryLoaderSuccess() {
         let primaryFeed = uniqueFeed()
@@ -44,25 +44,5 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
-    }
-
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result,
-                        file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait to load completion")
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-                case let (.success(receviedFeed), .success(expectedFeed)):
-                    XCTAssertEqual(receviedFeed, expectedFeed, file: file, line: line)
-
-                case (.failure, .failure):
-                    break
-
-                default:
-                    XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            exp.fulfill()
-        }
-
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
@@ -1,0 +1,39 @@
+//
+//  FeedImageDataLoaderSpy.swift
+//  EssentialAppTests
+//
+//  Created by Viral on 15/10/22.
+//
+
+import Foundation
+import EssentialFeed
+
+final class FeedImageDataLoaderSpy: FeedImageDataLoader {
+    private var message = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+    private(set) var cancelledURLs = [URL]()
+
+    var loadedURLs: [URL] {
+        return message.map { $0.url }
+    }
+
+    private struct Task: FeedImageDataLoaderTask {
+        let callback: () -> Void
+        func cancel() { callback() }
+    }
+
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void)
+    -> FeedImageDataLoaderTask {
+        message.append((url, completion))
+        return Task { [weak self] in
+            self?.cancelledURLs.append(url)
+        }
+    }
+
+    func complete(with error: Error, at index: Int = 0) {
+        message[index].completion(.failure(error))
+    }
+
+    func complete(with data: Data, at index: Int = 0) {
+        message[index].completion(.success(data))
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
@@ -1,0 +1,20 @@
+//
+//  FeedLoaderStub.swift
+//  EssentialAppTests
+//
+//  Created by Viral on 10/10/22.
+//
+
+import EssentialFeed
+
+class FeedLoaderStub: FeedLoader {
+    private let result: FeedLoader.Result
+
+    init(result: FeedLoader.Result) {
+        self.result = result
+    }
+
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        completion(result)
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import EssentialFeed
 
 func anyURL() -> URL {
     URL(string: "http://a-url.com")!
@@ -17,4 +18,8 @@ func anyNSError() -> NSError {
 
 func anyData() -> Data {
     return Data("anyData".utf8)
+}
+
+func uniqueFeed() -> [FeedImage] {
+    [FeedImage(id: UUID(), description: nil, location: nil, url: URL(string: "http://any-url.com")!)]
 }

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
@@ -1,0 +1,37 @@
+//
+//  XCTestCase+FeedImageDataLoader.swift
+//  EssentialAppTests
+//
+//  Created by Viral on 15/10/22.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedImageDataLoaderTestCase: XCTestCase {}
+
+extension FeedImageDataLoaderTestCase {
+    func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result,
+                when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+                case let (.success(receivedFeed), .success(expectedFeed)):
+                    XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+
+                case (.failure, .failure):
+                    break
+
+                default:
+                    XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+
+            exp.fulfill()
+        }
+
+        action()
+
+        wait(for: [exp], timeout: 1.0)
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
@@ -1,0 +1,33 @@
+//
+//  XCTestCase+FeedLoader.swift
+//  EssentialAppTests
+//
+//  Created by Viral on 10/10/22.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedLoaderTestCases: XCTestCase {}
+
+extension FeedLoaderTestCases {
+    func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result,
+                        file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait to load completion")
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+                case let (.success(receviedFeed), .success(expectedFeed)):
+                    XCTAssertEqual(receviedFeed, expectedFeed, file: file, line: line)
+
+                case (.failure, .failure):
+                    break
+
+                default:
+                    XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1.0)
+    }
+}

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		E0B497D828E03E510099BA29 /* LoadFeedImageDataFromCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B497D728E03E510099BA29 /* LoadFeedImageDataFromCacheUseCaseTests.swift */; };
 		E0B497DD28E1E7790099BA29 /* FeedImageDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B497DC28E1E7790099BA29 /* FeedImageDataSource.swift */; };
 		E0B497DF28E1E7CF0099BA29 /* LocalFeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B497DE28E1E7CF0099BA29 /* LocalFeedImageDataLoader.swift */; };
+		E0BA1B4428FB136400F1F75B /* FeedImageDataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BA1B4328FB136400F1F75B /* FeedImageDataCache.swift */; };
 		E0D0AFED27F1775A004CAEDE /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E0F95A5027E8F3DB000A2C16 /* EssentialFeed.framework */; platformFilter = ios; };
 		E0D0AFF427F17784004CAEDE /* EssentialFeedAPIEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D0AFF327F17784004CAEDE /* EssentialFeedAPIEndToEndTests.swift */; };
 		E0D0AFF527F177B0004CAEDE /* XCTestCase+MemoryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0614CDB2771F00600546A3D /* XCTestCase+MemoryTracker.swift */; };
@@ -204,6 +205,7 @@
 		E0B497D728E03E510099BA29 /* LoadFeedImageDataFromCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedImageDataFromCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		E0B497DC28E1E7790099BA29 /* FeedImageDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataSource.swift; sourceTree = "<group>"; };
 		E0B497DE28E1E7CF0099BA29 /* LocalFeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedImageDataLoader.swift; sourceTree = "<group>"; };
+		E0BA1B4328FB136400F1F75B /* FeedImageDataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataCache.swift; sourceTree = "<group>"; };
 		E0CC315E2756A9C400CC3E0C /* FeedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImage.swift; sourceTree = "<group>"; };
 		E0CC31602756AA4300CC3E0C /* FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoader.swift; sourceTree = "<group>"; };
 		E0D0AFE927F1775A004CAEDE /* EssentialFeedAPIEndToEndTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedAPIEndToEndTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -453,6 +455,7 @@
 				E0CC31602756AA4300CC3E0C /* FeedLoader.swift */,
 				E0952EC628F743AA0011FE47 /* FeedCache.swift */,
 				E00431A628AB2D30001AC895 /* FeedImageDataLoader.swift */,
+				E0BA1B4328FB136400F1F75B /* FeedImageDataCache.swift */,
 			);
 			path = "Feed Feature";
 			sourceTree = "<group>";
@@ -928,6 +931,7 @@
 				E0014A7F27E90207005D708A /* HTTPClient.swift in Sources */,
 				E0014A8027E90207005D708A /* FeedItemsMapper.swift in Sources */,
 				E0014A8127E90207005D708A /* RemoteFeedItem.swift in Sources */,
+				E0BA1B4428FB136400F1F75B /* FeedImageDataCache.swift in Sources */,
 				E00431A528AAC8AA001AC895 /* FeedImageViewModel.swift in Sources */,
 				E0B497DD28E1E7790099BA29 /* FeedImageDataSource.swift in Sources */,
 				E0FEB64F28C4C86300967844 /* RemoteFeedImageDataLoader.swift in Sources */,

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		E0636F9B28E9AD9700B6A455 /* CoreDataFeedStore+FeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0636F9A28E9AD9700B6A455 /* CoreDataFeedStore+FeedStore.swift */; };
 		E07BEE6D28841A9E000ED638 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07BEE6C28841A9E000ED638 /* ErrorView.swift */; };
 		E07E590C27FD964D0094AF29 /* FeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07E590B27FD964D0094AF29 /* FeedViewController.swift */; };
+		E0952EC728F743AA0011FE47 /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0952EC628F743AA0011FE47 /* FeedCache.swift */; };
 		E0992F482813D537000F4FC3 /* FeedImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0992F472813D537000F4FC3 /* FeedImageCell.swift */; };
 		E0992F4A28141305000F4FC3 /* UIView+Shimmering.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0992F4928141305000F4FC3 /* UIView+Shimmering.swift */; };
 		E0A2D7BB28538E7C00D9077B /* FeedUIIntegrationTests+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A2D7BA28538E7C00D9077B /* FeedUIIntegrationTests+Localization.swift */; };
@@ -187,6 +188,7 @@
 		E091743327A69D9000A95E7F /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableRetrieveFeedStoreSpecs.swift"; sourceTree = "<group>"; };
 		E091743527A69E8E00A95E7F /* XCTestCase+FailableInsertFeedStoreSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableInsertFeedStoreSpecs.swift"; sourceTree = "<group>"; };
 		E091743727A6A5BF00A95E7F /* XCTestCase+FailableDeleteFeedStoreSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableDeleteFeedStoreSpecs.swift"; sourceTree = "<group>"; };
+		E0952EC628F743AA0011FE47 /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
 		E0992F472813D537000F4FC3 /* FeedImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageCell.swift; sourceTree = "<group>"; };
 		E0992F4928141305000F4FC3 /* UIView+Shimmering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Shimmering.swift"; sourceTree = "<group>"; };
 		E0A2D7BA28538E7C00D9077B /* FeedUIIntegrationTests+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedUIIntegrationTests+Localization.swift"; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 			children = (
 				E0CC315E2756A9C400CC3E0C /* FeedImage.swift */,
 				E0CC31602756AA4300CC3E0C /* FeedLoader.swift */,
+				E0952EC628F743AA0011FE47 /* FeedCache.swift */,
 				E00431A628AB2D30001AC895 /* FeedImageDataLoader.swift */,
 			);
 			path = "Feed Feature";
@@ -920,6 +923,7 @@
 				E0014A7D27E90207005D708A /* FeedCachePolicy.swift in Sources */,
 				E0FEB65128C5B44200967844 /* HTTPURLResponse+StatusCode.swift in Sources */,
 				E0014A7E27E90207005D708A /* RemoteFeedLoader.swift in Sources */,
+				E0952EC728F743AA0011FE47 /* FeedCache.swift in Sources */,
 				E0636F9928E9961500B6A455 /* CoreDataFeedStore+FeedImageDataLoader.swift in Sources */,
 				E0014A7F27E90207005D708A /* HTTPClient.swift in Sources */,
 				E0014A8027E90207005D708A /* FeedItemsMapper.swift in Sources */,

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
@@ -16,8 +16,8 @@ public final class LocalFeedImageDataLoader {
     }
 }
 
-extension LocalFeedImageDataLoader {
-    public typealias SaveResult = Result<Void, Swift.Error>
+extension LocalFeedImageDataLoader: FeedImageDataCache {
+    public typealias SaveResult = FeedImageDataCache.Result
 
     public enum SaveError: Error {
         case failed

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -17,8 +17,8 @@ public final class LocalFeedLoader {
     }
 }
 
-extension LocalFeedLoader {
-    public typealias SaveResult = Result<Void, Error>
+extension LocalFeedLoader: FeedCache {
+    public typealias SaveResult = FeedCache.Result
 
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
         store.deleteCacheFeed { [weak self] deleteResult in

--- a/EssentialFeed/EssentialFeed/Feed Feature/FeedCache.swift
+++ b/EssentialFeed/EssentialFeed/Feed Feature/FeedCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedCache.swift
+//  EssentialFeed
+//
+//  Created by Viral on 13/10/22.
+//
+
+import Foundation
+
+public protocol FeedCache {
+    typealias Result = Swift.Result<Void, Error>
+
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}

--- a/EssentialFeed/EssentialFeed/Feed Feature/FeedImageDataCache.swift
+++ b/EssentialFeed/EssentialFeed/Feed Feature/FeedImageDataCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedImageDataCache.swift
+//  EssentialFeed
+//
+//  Created by Viral on 15/10/22.
+//
+
+import Foundation
+
+public protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}


### PR DESCRIPTION
Added [*]LoaderCacheDecorators responsible for decorating (intercepting) load operations and injecting the save side-effect on successful load results.

We can now use the decorators to compose the RemoteFeedLoader.loadwith the LocalFeedLoader.save operations in a simple, clean, extendable, modular, and testable way.