### PR TITLE
Guarantee Main Dispatch Queue on custom Scheduler

### DIFF
--- a/EssentialApp/EssentialApp/CombineHelpers.swift
+++ b/EssentialApp/EssentialApp/CombineHelpers.swift
@@ -77,7 +77,7 @@ extension Publisher {
 extension DispatchQueue {
 
     static var immediateWhenOnMainQueueScheduler: ImmediateWhenOnMainQueueScheduler {
-        ImmediateWhenOnMainQueueScheduler()
+        ImmediateWhenOnMainQueueScheduler.shared
     }
 
     struct ImmediateWhenOnMainQueueScheduler: Scheduler {
@@ -92,8 +92,21 @@ extension DispatchQueue {
             DispatchQueue.main.minimumTolerance
         }
 
+        static let shared = Self()
+
+        private static let key = DispatchSpecificKey<UInt8>()
+        private static let value = UInt8.max
+
+        init() {
+            DispatchQueue.main.setSpecific(key: Self.key, value: Self.value)
+        }
+
+        private func isMainQueue() -> Bool {
+            DispatchQueue.getSpecific(key: Self.key) == Self.value
+        }
+
         func schedule(options: SchedulerOptions?, _ action: @escaping () -> Void) {
-            guard Thread.isMainThread else {
+            guard isMainQueue() else {
                 return DispatchQueue.main.schedule(options: options, action)
             }
 


### PR DESCRIPTION
Check isMainQueue instead of just isMainThread since there's no guarantee that the main thread is running the main queue.